### PR TITLE
Update Fathom analytics integration

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
   <title>Mini-dashboard | Meilisearch</title>
+  <!-- Fathom analytics -->
   <script src="https://cdn.usefathom.com/script.js" data-site="QNBPJXIV" defer></script>
 </head>
 

--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
   <title>Mini-dashboard | Meilisearch</title>
+  <script src="https://cdn.usefathom.com/script.js" data-site="QNBPJXIV" defer></script>
 </head>
 
 <body>

--- a/src/App.js
+++ b/src/App.js
@@ -25,18 +25,6 @@ const Wrapper = styled.div`
   min-height: 100vh;
 `
 
-const Scripts = () => {
-  if (process.env.NODE_ENV === 'development') {
-    return null
-  }
-  const fathomTrackingCode = process.env.REACT_APP_FATHOM_TRACKING_CODE
-  return (<script
-    id="fathom-script"
-    src="https://cdn.usefathom.com/script.js"
-    data-site={fathomTrackingCode}
-  />)
-}
-
 const App = () => {
   useEffect(() => {
     document.title = "Search in millions of musics with Meilisearch";
@@ -100,7 +88,6 @@ const App = () => {
         <Wrapper>
           <>
             <Body currentIndex={currentIndex} setCurrentIndex={setCurrentIndex} />
-            <Scripts />
           </>
         </Wrapper>
       </ApiKeyContext.Provider>


### PR DESCRIPTION
Fix #10 

## Motivation

This PR updates the integration of the Fathom analytics script. It no longer uses the environment variable to inject the site ID because doing so would complicate the deploy script or the index.html in ways that are not worth it for a demo.

## How

- Adds fathom script to <head> (with `defer` attribute) instead of the the bottom of <body>
- Removes the `Scripts` component from `App.js`

## Notes

After merging this, we can remove the `REACT_APP_FATHOM_TRACKING_CODE` repository secret.